### PR TITLE
update: add test to verify phone number that start with 011...

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
@@ -107,7 +107,7 @@ class TestB2CPaymentDisbursementReference(FrappeTestCase):
             self.assertFalse(is_valid_receiver_contact(contact))
 
     def test_is_valid_reciever_contact_for_011_phone_numbers(self):
-        """Test that the is_valid_receiver_contact function correctly identifies 011 phone numbers as invalid"""
+        """Test that the is_valid_receiver_contact function correctly identifies 011 phone numbers as valid"""
         invalid_contacts = [
             "0112345678",
             "01123456789",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
@@ -79,6 +79,7 @@ class TestB2CPaymentDisbursementReference(FrappeTestCase):
             ("25471234567", "25471234567"),
             ("0712345678a", "0712345678a"),
             ("0712345678 ", "0712345678 "),
+            ("0112345678", "0112345678"),
         ]
 
         for input_number, expected_output in test_cases:
@@ -104,3 +105,15 @@ class TestB2CPaymentDisbursementReference(FrappeTestCase):
 
         for contact in invalid_contacts:
             self.assertFalse(is_valid_receiver_contact(contact))
+
+    def test_is_valid_reciever_contact_for_011_phone_numbers(self):
+        """Test that the is_valid_receiver_contact function correctly identifies 011 phone numbers as invalid"""
+        invalid_contacts = [
+            "0112345678",
+            "01123456789",
+            "+254112345678",
+            "254112345678",
+        ]
+
+        for contact in invalid_contacts:
+            self.assertTrue(is_valid_receiver_contact(contact))


### PR DESCRIPTION
This pull request updates the test suite for validating phone numbers in the `frappe_mpsa_payments` module. It introduces support for testing `011` phone numbers and ensures they are correctly identified as invalid when necessary.

### Updates to phone number validation tests:

* [`frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py`](diffhunk://#diff-f1e8d1488847f3deeeb518dbe0c095e7a73dbb67325911cba53a5499ff5b7714R82): Added a new test case in `test_sanitise_phone_number_invalid` to include `0112345678` as a valid input for sanitization tests.
* [`frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py`](diffhunk://#diff-f1e8d1488847f3deeeb518dbe0c095e7a73dbb67325911cba53a5499ff5b7714R108-R119): Added a new test method `test_is_valid_reciever_contact_for_011_phone_numbers` to verify that `is_valid_receiver_contact` correctly identifies `011` phone numbers as valid.